### PR TITLE
fix string color of current holdings

### DIFF
--- a/qml/PortfolioPage.qml
+++ b/qml/PortfolioPage.qml
@@ -79,6 +79,7 @@ Page {
             // === Holdings Header ===
             Text {
                 text: "Your Holdings" + " Worth ($" + totalValue.toFixed(2)+")"
+                color:AppTheme.getThemeColors(theme.name).textColorPrimary
                 font.bold: true
                 font.pixelSize: units.gu(2.2)
             }


### PR DESCRIPTION
Currently the account holdings text comes up as black on black or white on white and so is not readable. Fixing this by using the text color.