### PR TITLE
drop not used location permission

### DIFF
--- a/ubcrypto.apparmor
+++ b/ubcrypto.apparmor
@@ -1,6 +1,5 @@
 {
     "policy_groups": [
-        "location",
         "networking",
         "connectivity",
         "content_exchange"


### PR DESCRIPTION
I could not see a place where location is used. So this permission should/could be dropped.