### PR TITLE
fix negaitve amount less than one dollar being displayed green

### DIFF
--- a/qml/PortfolioItem.qml
+++ b/qml/PortfolioItem.qml
@@ -103,7 +103,7 @@ ListItem {
                     value:Number(delta).toFixed(2)
                     font.bold: false
                     font.pixelSize: units.gu(1.5)
-                    color: Number(delta) < -1 ? "red" : "#2e7d32"  // red for loss, green for profit
+                    color: Number(delta) < 0 ? "red" : "#2e7d32"  // red for loss, green for profit
                     horizontalAlignment: Text.AlignRight
                 }
 


### PR DESCRIPTION
Currently negative changes of less than one dollar are shown green. Only full dollars are displayed red. So change the compare value to zero so also smaller negative amounts are displayed in red.